### PR TITLE
feat: [PR-14] Use redis host variable instead

### DIFF
--- a/plugins/redis.ts
+++ b/plugins/redis.ts
@@ -11,8 +11,8 @@ function buildRedisClientPlugin(
   fastify.log.info("Building Redis client");
 
   const redis = new Redis({
-    host: "redis",
-    port: 6379,
+    host: config.host,
+    port: 6379, // Setting this here as is the port where redis will run on the container
     db: config.db ?? 0,
   });
 


### PR DESCRIPTION
This PR is intended to use all environment redis variables in our environment file.